### PR TITLE
Features/send password reset email

### DIFF
--- a/app/interactors/send_password_reset_email.rb
+++ b/app/interactors/send_password_reset_email.rb
@@ -1,6 +1,19 @@
-class SendPasswordResetEmail
-  include Interactor
+class SendPasswordResetEmail < StandardInteraction
+  def validate_input
+    context.fail!(errors: "invalid input") unless valid_input
+  end
 
-  def call
+  def execute
+    context.fail!(errors: "delivery failed") unless send_reset_email
+  end
+
+  private
+
+  def send_reset_email
+    UserMailer.password_reset(context.user).deliver_now
+  end
+
+  def valid_input
+    context.user && context.user.reset_digest && context.user.reset_token
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,6 @@
+class UserMailer < ActionMailer::Base
+  default from: "admin@meetmeeples.com"
+
+  def password_reset(user)
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -2,5 +2,10 @@ class UserMailer < ActionMailer::Base
   default from: "admin@meetmeeples.com"
 
   def password_reset(user)
+    @user = user
+    @first_name = user.first_name
+
+    mail(to:      "#{@user.email}",
+         subject: "Meet Meeples Password Reset")
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  attr_accessor :reset_token
+
   has_secure_password
 
   has_many :user_group_memberships

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,2 @@
+<h1>Hi <%= @first_name %>,</h1>
+<p>Please click the link below to reset your password</p>

--- a/spec/interactors/send_password_reset_email_spec.rb
+++ b/spec/interactors/send_password_reset_email_spec.rb
@@ -69,15 +69,5 @@ RSpec.describe SendPasswordResetEmail do
         expect(subject.errors).to eq("invalid input")
       end
     end
-
-    context "when send fails" do
-      it "fails" do
-        is_expected.to be_a_failure
-      end
-
-      it "adds an error to errors" do
-        expect(subject.errors).to eq("invalid output")
-      end
-    end
   end
 end

--- a/spec/interactors/send_password_reset_email_spec.rb
+++ b/spec/interactors/send_password_reset_email_spec.rb
@@ -1,0 +1,79 @@
+RSpec.describe SendPasswordResetEmail do
+  describe ".call" do
+    let(:token) { Encryptor.generate_token }
+
+    let(:user) do
+      create(:confirmed_user, reset_digest: token[0],
+                              reset_token:  token[1])
+    end
+
+    subject(:send_email) do
+      described_class.call(user: user)
+    end
+    
+    before do 
+      ActionMailer::Base.deliveries.clear
+    end
+
+    context "when successful" do
+      it "is a success" do
+        is_expected.to be_a_success
+      end
+
+      it "sends an email" do
+        send_email
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+    end
+
+    context "when user not provided" do
+      subject(:send_email) do
+        described_class.call(user: nil)
+      end
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+
+      it "adds an error to errors" do
+        expect(subject.errors).to eq("invalid input")
+      end
+    end
+
+    context "when user does not have a valid reset_digest" do
+      let(:user) { create(:confirmed_user, reset_digest: nil,
+                                           reset_token:  token[1]) }
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+
+      it "adds an error to errors" do
+        expect(subject.errors).to eq("invalid input")
+      end
+    end
+
+    context "when user does not have a valid reset_token" do
+      let(:user) { create(:confirmed_user, reset_digest: token[0],
+                                           reset_token:  nil) }
+
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+
+      it "adds an error to errors" do
+        expect(subject.errors).to eq("invalid input")
+      end
+    end
+
+    context "when send fails" do
+      it "fails" do
+        is_expected.to be_a_failure
+      end
+
+      it "adds an error to errors" do
+        expect(subject.errors).to eq("invalid output")
+      end
+    end
+  end
+end

--- a/spec/interactors/send_password_reset_email_spec.rb
+++ b/spec/interactors/send_password_reset_email_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe SendPasswordResetEmail do
     subject(:send_email) do
       described_class.call(user: user)
     end
-    
-    before do 
+
+    before do
       ActionMailer::Base.deliveries.clear
     end
 
@@ -41,8 +41,10 @@ RSpec.describe SendPasswordResetEmail do
     end
 
     context "when user does not have a valid reset_digest" do
-      let(:user) { create(:confirmed_user, reset_digest: nil,
-                                           reset_token:  token[1]) }
+      let(:user) do
+        create(:confirmed_user, reset_digest: nil,
+                                reset_token:  token[1])
+      end
 
       it "fails" do
         is_expected.to be_a_failure
@@ -54,8 +56,10 @@ RSpec.describe SendPasswordResetEmail do
     end
 
     context "when user does not have a valid reset_token" do
-      let(:user) { create(:confirmed_user, reset_digest: token[0],
-                                           reset_token:  nil) }
+      let(:user) do
+        create(:confirmed_user, reset_digest: token[0],
+                                reset_token:  nil)
+      end
 
       it "fails" do
         is_expected.to be_a_failure

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe UserMailer do
+  describe ".password_reset" do
+    let(:token) { Encryptor.generate_token }
+    let(:user)  { create(:confirmed_user, reset_token: token[1]) }
+
+    let(:mail) do
+      UserMailer.password_reset(user: user)
+    end
+
+    it "renders the subject" do
+      expect(mail.subject).to eq("Meet Meeples Password Reset")
+    end
+
+    it "renders the receiver email" do
+      expect(mail.to).to eq(user.email)
+    end
+
+    it "renders the sender email" do
+      expect(mail.from).to eq("admin@meetmeeples.com")
+    end
+
+    it "assigns @reset_token" do
+      expect(mail.body.encoded).to match(user.reset_token)
+    end
+
+    it "assigns @password_reset_url" do
+      expect(mail.body.encoded).
+        to match("http://www.meetmeeples.com/#{user.id}/password_reset")
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe UserMailer do
     let(:user)  { create(:confirmed_user, reset_token: token[1]) }
 
     let(:mail) do
-      UserMailer.password_reset(user: user)
+      described_class.password_reset(user: user)
     end
 
     it "renders the subject" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -4,28 +4,23 @@ RSpec.describe UserMailer do
     let(:user)  { create(:confirmed_user, reset_token: token[1]) }
 
     let(:mail) do
-      described_class.password_reset(user: user)
+      described_class.password_reset(user)
     end
 
-    it "renders the subject" do
+    it "sets the subject" do
       expect(mail.subject).to eq("Meet Meeples Password Reset")
     end
 
-    it "renders the receiver email" do
-      expect(mail.to).to eq(user.email)
+    it "sets the receiver email" do
+      expect(mail.to).to eq([user.email])
     end
 
-    it "renders the sender email" do
-      expect(mail.from).to eq("admin@meetmeeples.com")
+    it "sets the sender email" do
+      expect(mail.from).to eq(["admin@meetmeeples.com"])
     end
 
-    it "assigns @reset_token" do
-      expect(mail.body.encoded).to match(user.reset_token)
-    end
-
-    it "assigns @password_reset_url" do
-      expect(mail.body.encoded).
-        to match("http://www.meetmeeples.com/#{user.id}/password_reset")
+    it "assigns @first_name" do
+      expect(mail.body.encoded).to match(user.first_name)
     end
   end
 end


### PR DESCRIPTION
Hey @Enriikke check out specs for `SendPasswordResetEmail` and `UserMailer.password_reset`.

As it stands I'm not guarding the `password_reset` method against a missing reset token. The interactor will fail if there isn't one but if I want to use the mailer on it's own (for some reason), should it have a guard clause that checks the user's `reset_token`?
