### PR TITLE
remove ShowUser rescue

### DIFF
--- a/app/interactors/show_user.rb
+++ b/app/interactors/show_user.rb
@@ -5,11 +5,5 @@ class ShowUser < StandardInteraction
 
   def execute
     context.user = User.find(context.id)
-  rescue ActiveRecord::RecordNotFound
-    context.user = nil
-  end
-
-  def validate_output
-    context.fail!(error: "invalid user") unless context.user
   end
 end

--- a/spec/interactors/show_user_spec.rb
+++ b/spec/interactors/show_user_spec.rb
@@ -29,19 +29,5 @@ RSpec.describe ShowUser do
         expect(subject.error).to eq("invalid user id")
       end
     end
-
-    context "when user output is invalid" do
-      subject do
-        described_class.call(id: 0)
-      end
-
-      it "fails" do
-        is_expected.to be_a_failure
-      end
-
-      it "returns an error" do
-        expect(subject.error).to eq("invalid user")
-      end
-    end
   end
 end


### PR DESCRIPTION
We'd talked about this previously. I think it's probably better to just raise the `RecordNotFound` exception rather than obscuring.
