### PR TITLE
Features/interactor-errors

### DIFF
--- a/app/interactors/create_user.rb
+++ b/app/interactors/create_user.rb
@@ -1,6 +1,6 @@
 class CreateUser < StandardInteraction
-  def validate_input
-    context.fail!(errors: "invalid user params") unless context.user_params
+  def validate_input(input: :user_params)
+    super
   end
 
   def execute

--- a/lib/standard_interaction.rb
+++ b/lib/standard_interaction.rb
@@ -10,9 +10,14 @@ class StandardInteraction
   def execute
   end
 
-  def validate_input
+  def validate_input(input: expected_arguments)
+    context.fail!(errors: input_error) unless context.send(input)
   end
 
   def validate_output
+  end
+
+  def input_error
+    { "#{self.class.name}": "invalid Interactor input" }
   end
 end

--- a/spec/interactors/create_user_spec.rb
+++ b/spec/interactors/create_user_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CreateUser do
       end
 
       it "returns an error" do
-        expect(subject.errors).to eq("invalid user params")
+        expect(subject.errors).to eq(CreateUser: "invalid Interactor input")
       end
     end
   end


### PR DESCRIPTION
Hey @Enriikke what do you think of this approach for Interactor error handling? Right now you would just define --

``` ruby
def validate_input(input: :this_is_the_expected_input)
  # fail with an error that points to this Interactor (defined in parent class)
end
```

And then `input_error` would add some very basic details to the Interactor's `errors`. All defined in the parent class.

There probably wouldn't need to be a generalized `output_errors` because that's mostly AR validation stuff (`errors: context.model.errors`). Though I guess things like `show` would need something special...

In any case, how would you make this cooler :smile:?
